### PR TITLE
Update Tmux config

### DIFF
--- a/shell/tmux/tmux.conf
+++ b/shell/tmux/tmux.conf
@@ -1,8 +1,9 @@
-# remap prefix from 'C-b' to 'C-Space'
+# Unbind defaults
 unbind C-b
 unbind C-Space
-set-option -g prefix C-Space
-bind-key C-Space send-prefix
+
+# Conditional prefix using shell
+if-shell '[ -z "$SSH_TTY" ]' 'set-option -g prefix C-Space' 'set-option -g prefix C-b'
 
 # split panes using | and -
 bind \\ split-window -h -c "#{pane_current_path}"

--- a/shell/tmux/tmux.conf
+++ b/shell/tmux/tmux.conf
@@ -64,8 +64,3 @@ set -g default-terminal "screen-256color"
 # # see https://github.com/tmux/tmux/issues/696
 # # see https://stackoverflow.com/a/41786092
 set-option -ga terminal-overrides ",xterm-256color:Tc"
-
-# Pass VS Code variables into tmux environment
-set-environment -g VSCODE_PID "$VSCODE_PID"
-set-environment -g VSCODE_IPC_HOOK "$VSCODE_IPC_HOOK"
-set-environment -g TERM_PROGRAM "$TERM_PROGRAM"

--- a/shell/zsh/zshrc
+++ b/shell/zsh/zshrc
@@ -79,15 +79,16 @@ ZSH_THEME="powerlevel10k/powerlevel10k"
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(git tmux zsh-autosuggestions zsh-syntax-highlighting)
 
-ZSH_TMUX_AUTOSTART=false
-ZSH_TMUX_AUTOSTART_ONCE=false
-ZSH_TMUX_AUTOCONNECT=false
 ZSH_TMUX_FIXTERM=true
 
-# use tmux injected env vars to determine if this is vscode or not so tmux gets started
-if [[ -z "$TERM_PROGRAM" ]]; then
-  ZSH_TMUX_AUTOSTART=true
- fi
+# Only autostart tmux in real local terminals outside of VSCode
+if [[ -t 1 && -z "$SSH_TTY" && "$TERM_PROGRAM" != "vscode" ]]; then
+    ZSH_TMUX_AUTOSTART=true
+    ZSH_TMUX_AUTOCONNECT=true
+else
+    ZSH_TMUX_AUTOSTART=false
+    ZSH_TMUX_AUTOCONNECT=false
+fi
 
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
ssh into a host with identical config would kill itself after first exit because it wouldn't spawn tmux again and thus exit. this deals with that and also makes it easier to send a prefix that doesn't collide with the local